### PR TITLE
Fix redux devtools error for those without

### DIFF
--- a/client/src/Root.js
+++ b/client/src/Root.js
@@ -4,6 +4,8 @@ import { createStore, applyMiddleware, compose } from 'redux';
 import reduxThunk from 'redux-thunk';
 import reducers from './reducers';
 
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
 export default ({ children }) => {
   
   const store = createStore(
@@ -13,9 +15,8 @@ export default ({ children }) => {
         status: 'fetching'
       }
     }, 
-    compose(
+    composeEnhancers(
       applyMiddleware(reduxThunk),
-      window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
     )
   );
 


### PR DESCRIPTION
# Issue

Resolves a fatal error on the front-end when attempting to run the app without having the Redux Devtools browser extension installed.

# Description

Updates Redux Devtools config to match this doc:

https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup
