### PR TITLE
Fix requireAuth HOC

### DIFF
--- a/client/src/components/HOC/requireAuth.js
+++ b/client/src/components/HOC/requireAuth.js
@@ -8,15 +8,19 @@ export default (ChildComponent) => {
     shouldNavigateAway = () => {
       if(this.props.auth.status === 'fetching') {
         return <div>Loading...</div>
-
       } else if (this.props.auth.status === false) {
-        return this.props.history.push('/');
-        
+        return <div>Not authorized</div>
       } else {
         return <ChildComponent {...this.props} />
       }
     }
 
+    componentDidMount() {
+      if (!this.props.auth.status) {
+        this.props.history.push('/');
+      }
+    }
+    
     render() {
       return (
         <Fragment>


### PR DESCRIPTION
# Issue

This issue resolves #126

# Description

I think the error you were getting was a result of pushing to the router history inside of the render method (a side effect).  I believe React expects render() to only return a React Element.  I think the history push was confusing it by triggering a re-render before the wrapped component's render() finished.
