### PR TITLE
Improve music library keyword search

### DIFF
--- a/controllers/searchController.js
+++ b/controllers/searchController.js
@@ -1,27 +1,87 @@
 const db = require('../models');
 
+/**
+ * Flattens an array of arrays into one flat array.
+ * @example
+ * // returns [1, 2, 3, 4, 5, 6]
+ * concatArrays([[1, 2], [3, 4], [5, 6]]);
+ */
+function concatArrays(arrays) {
+  return arrays.reduce((acc, val) => [...acc, ...val]);
+}
+
+/**
+ * Removes duplicate objects from a results array.
+ * Objects are considered duplicates if their _id and type members are equal.
+ */
+function filterDuplicates(results) {
+  return results.reduce(
+    (acc, result) => {
+      const key = result.type + result._id;
+      if (acc.seen.has(key)) {
+        return acc;
+      }
+      acc.seen.add(key);
+      acc.filteredResults.push(result);
+      return acc;
+    },
+    {
+      seen: new Set(),
+      filteredResults: [],
+    }
+  ).filteredResults;
+}
+
 module.exports = {
   searchLibrary: async (req, res) => {
     const { searchTerm } = req.body;
-    const q = new RegExp(searchTerm, 'i');
 
-    if(searchTerm === '') {
+    if (searchTerm === '') {
       return res.json([]);
     }
 
-    const albumResults = await db.Album.find({ name: q });
-    const artistResults = await db.Artist.find({ name: q })
-    const trackResults = await db.Track.find({ name: q }); 
+    const queryAll = new RegExp(searchTerm, 'i');
 
-    const data = [
-      ...albumResults, 
-      ...artistResults, 
-      ...trackResults
-    ].sort((a, b) => {
-      if(a.name < b.name) return -1;
-      if(a.name > b.name) return 1;
-      return 0;
-    });
+    const resultSetsAll = await Promise.all([
+      db.Album.find({ name: queryAll }),
+      db.Artist.find({ name: queryAll }),
+      db.Track.find({ name: queryAll }),
+    ]);
+
+    const resultsAll = concatArrays(resultSetsAll);
+
+    if (/\s/.test(searchTerm)) {
+      const queryAny = new RegExp(
+        searchTerm
+          .split(/\s/)
+          .map(term => `(${term})`)
+          .join('|'),
+        'i'
+      );
+
+      const resultSetsAny = await Promise.all([
+        db.Album.find({ name: queryAny }),
+        db.Artist.find({ name: queryAny }),
+        db.Track.find({ name: queryAny }),
+      ]);
+
+      const resultsAny = concatArrays(resultSetsAny);
+
+      results = [...resultsAll, ...resultsAny];
+    } else {
+      results = [...resultsAll];
+    }
+
+    const data = filterDuplicates(
+      results.sort((a, b) => {
+        // Sort the results that match the whole string first, then alphabetically
+        if (a.matchType === 'all') return -1;
+        if (a.matchType === 'any') return 1;
+        if (a.name < b.name) return -1;
+        if (a.name > b.name) return 1;
+        return 0;
+      })
+    );
 
     return res.json(data);
   },
@@ -30,16 +90,16 @@ module.exports = {
     const { searchTerm } = req.body;
     const q = new RegExp(searchTerm, 'i');
 
-    const userResults = await db.User.find({ $or: [{ email: q }, { first_name: q }, { last_name: q }] });
+    const userResults = await db.User.find({
+      $or: [{ email: q }, { first_name: q }, { last_name: q }],
+    });
 
-    const data = [
-      ...userResults
-    ].sort((a, b) => {
-      if(a.last_name < b.last_name) return -1;
-      if(a.last_name > b.last_name) return 1;
+    const data = [...userResults].sort((a, b) => {
+      if (a.last_name < b.last_name) return -1;
+      if (a.last_name > b.last_name) return 1;
       return 0;
     });
 
     return res.json(data);
-  }
-}
+  },
+};

--- a/controllers/searchController.js
+++ b/controllers/searchController.js
@@ -36,7 +36,7 @@ function filterDuplicates(results) {
  * Queries the Album, Artist, and Track collections for a given query string
  * and populates the relationships in Track.
  */
-async function searchLibrary(query) {
+async function findInLibrary(query) {
   const queryRegexp = new RegExp(query, 'i');
   const resultSets = await Promise.all([
     db.Album.find({ name: queryRegexp }),
@@ -59,17 +59,19 @@ module.exports = {
       return res.json([]);
     }
 
-    const resultsAll = await searchLibrary(searchTerm);
+    const resultsAll = await findInLibrary(searchTerm);
 
     let results;
 
     if (/\s/.test(searchTerm)) {
+      // Construct a regex that searches each whitespace separated term
+      // separately.
       const queryAny = searchTerm
         .split(/\s/)
         .map(term => `(${term})`)
         .join('|');
 
-      const resultsAny = await searchLibrary(queryAny);
+      const resultsAny = await findInLibrary(queryAny);
 
       results = [...resultsAll, ...resultsAny];
     } else {


### PR DESCRIPTION
# Issue

This issue resolves #50 

# Description

This PR improves the searchLibrary controller function, adding the following capabilities:

* Splits the query input string into individual words and searches for a match in any of them
* Searches child documents (e.g. album artist, track artist, track album) for text matches
* Calculates relevance of search results -- if the query string matches the 'name' field of the document exactly, relevance is 100.  Otherwise, relevance is the number of word matches found in all searched fields.

There are better, more elegant ways to do search relevance, but I tried to keep it simple for the first attempt at this.  Later, we may want to look into adding something like ElasticSearch to handle this.  This may be especially necessary as the size of the music library increases.  With this approach we're doing a lot of MongoDB queries and iterating over the results with a bunch of RegExp matching, so I think the time complexity is pretty high.

Sorry for the commit mess -- I messed something up while trying to rebase onto development.  Should be fixed if we squash+merge.
