### PR TITLE
Replace styleName props with className

### DIFF
--- a/client/src/components/Alert/Alert.js
+++ b/client/src/components/Alert/Alert.js
@@ -60,11 +60,11 @@ class Alert extends Component {
       state,
     } = this;
     const { display } = state;
-    const { header, styleName, type, text, ...rest } = props;
+    const { header, className, type, text, ...rest } = props;
 
     return (
       <div
-        className={`alert ${getAlertClass(type)} ${display} ${styleName}`}
+        className={`alert ${getAlertClass(type)} ${display} ${className}`}
         {...rest}
       >
         <div className="alert__times" onClick={handleDisplayClick}>
@@ -86,9 +86,9 @@ Alert.propTypes = {
    */
   header: PropTypes.string,
   /**
-   * Additoinal classes added to element
+   * Additional classes added to root element
    */
-  styleName: PropTypes.string,
+  className: PropTypes.string,
   /**
    * Body Text
    */
@@ -100,7 +100,7 @@ Alert.propTypes = {
 };
 
 Alert.defaultProps = {
-  styleName: '',
+  className: '',
 };
 
 export default Alert;

--- a/client/src/components/Button/Button.js
+++ b/client/src/components/Button/Button.js
@@ -24,12 +24,12 @@ class Button extends Component {
 
   render() {
     const { getButtonClass, props } = this;
-    const { children, color, disabled, onClick, styleName, to, type } = props;
+    const { children, color, disabled, onClick, className, to, type } = props;
 
     if (to) {
       return (
         <Link
-          className={`button button--link ${styleName}`}
+          className={`button button--link ${className}`}
           disabled={disabled}
           onClick={onClick}
           to={to}
@@ -42,7 +42,7 @@ class Button extends Component {
 
     return (
       <button
-        className={`button ${getButtonClass(color)} ${styleName}`}
+        className={`button ${getButtonClass(color)} ${className}`}
         disabled={disabled}
         onClick={onClick}
         type={type}
@@ -83,7 +83,7 @@ Button.propTypes = {
   /**
    * Any additional classes added
    */
-  styleName: PropTypes.string,
+  className: PropTypes.string,
   /**
    * Make this button a Link instead
    */
@@ -96,7 +96,7 @@ Button.propTypes = {
 
 Button.defaultProps = {
   color: 'primary',
-  styleName: '',
+  className: '',
   type: 'button',
 };
 

--- a/client/src/components/Button/Button.md
+++ b/client/src/components/Button/Button.md
@@ -11,12 +11,12 @@
 
 <div className="mb-3">
   <h4>Buttons:Hover</h4>
-  <Button color="primary" styleName="hover">Primary</Button>
-  <Button color="success" styleName="hover">Success</Button>
-  <Button color="info" styleName="hover">Info</Button>
-  <Button color="danger" styleName="hover">Danger</Button>
-  <Button color="warning" styleName="hover">Warning</Button>
-  <Button color="link" styleName="hover">Link</Button>
+  <Button color="primary" className="hover">Primary</Button>
+  <Button color="success" className="hover">Success</Button>
+  <Button color="info" className="hover">Info</Button>
+  <Button color="danger" className="hover">Danger</Button>
+  <Button color="warning" className="hover">Warning</Button>
+  <Button color="link" className="hover">Link</Button>
 </div>
 
 <div>

--- a/client/src/components/Checkbox/Checkbox.js
+++ b/client/src/components/Checkbox/Checkbox.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
 const Checkbox = props => {
-  const { styleName, ...rest } = props;
+  const { className, ...rest } = props;
 
-  return <input className={`check-box ${styleName || ''}`} {...rest} />;
+  return <input className={`check-box ${className || ''}`} {...rest} />;
 };
 
 export default Checkbox;

--- a/client/src/components/Feedback/Feedback.js
+++ b/client/src/components/Feedback/Feedback.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
 const Feedback = props => {
-  const { children, styleName = '' } = props;
+  const { children, className = '' } = props;
 
-  return <div className={`feedback ${styleName}`}>{children}</div>;
+  return <div className={`feedback ${className}`}>{children}</div>;
 };
 
 export default Feedback;

--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
 const Footer = props => {
-  const { styleName } = props;
+  const { className } = props;
 
   return (
-    <footer className={`footer ${styleName || ''}`}>
+    <footer className={`footer ${className || ''}`}>
       <p className="footer__text">
         <img
           className="footer__logo"

--- a/client/src/components/Form/Form.js
+++ b/client/src/components/Form/Form.js
@@ -33,11 +33,11 @@ class Form extends Component {
   };
 
   render() {
-    const { children, onSubmit, styleName = '' } = this.props;
+    const { children, onSubmit, className = '' } = this.props;
 
     return (
       <form
-        className={`form ${styleName}`}
+        className={`form ${className}`}
         onSubmit={onSubmit || this.handleOnSubmit}
       >
         {children}

--- a/client/src/components/FormGroup/FormGroup.js
+++ b/client/src/components/FormGroup/FormGroup.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
 const FormGroup = props => {
-  const { children, styleName } = props;
+  const { children, className } = props;
 
-  return <div className={`form__group ${styleName || ''}`}>{children}</div>;
+  return <div className={`form__group ${className || ''}`}>{children}</div>;
 };
 
 export default FormGroup;

--- a/client/src/components/Input/Input.js
+++ b/client/src/components/Input/Input.js
@@ -69,7 +69,7 @@ class Input extends Component {
       label,
       name,
       type,
-      styleName = '',
+      className = '',
       validate,
     } = props;
 
@@ -77,7 +77,7 @@ class Input extends Component {
       <Fragment>
         <input
           ref={myRef}
-          className={`input ${styleName}`}
+          className={`input ${className}`}
           name={name}
           type={type}
           validate={validate}

--- a/client/src/components/Label/Label.js
+++ b/client/src/components/Label/Label.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
 const Label = props => {
-  const { children, styleName = '', ...rest } = props;
+  const { children, className = '', ...rest } = props;
 
   return (
-    <label className={`label ${styleName}`} {...rest}>
+    <label className={`label ${className}`} {...rest}>
       {children}
     </label>
   );

--- a/client/src/components/ResetPasswordForm/ResetPasswordForm.js
+++ b/client/src/components/ResetPasswordForm/ResetPasswordForm.js
@@ -14,7 +14,7 @@ class ResetPasswordForm extends Component {
     const { resetPassword } = this.props;
 
     return (
-      <Form action={resetPassword} styleName="mb-5">
+      <Form action={resetPassword} className="mb-5">
         <Alert />
         <p>Enter new Password Information</p>
         <FormGroup>

--- a/client/src/components/Select/Select.js
+++ b/client/src/components/Select/Select.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
 const Select = props => {
-  const { selectOptions, styleName, ...rest } = props;
+  const { selectOptions, className, ...rest } = props;
 
   return (
-    <select className={`select ${styleName || ''}`} {...rest}>
+    <select className={`select ${className || ''}`} {...rest}>
       <option value="" disabled defaultValue />
       {selectOptions.map((option, index) => (
         <option key={index} value={option}>

--- a/client/src/components/Table/Table.js
+++ b/client/src/components/Table/Table.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
 const Table = props => {
-  const { children, styleName } = props;
+  const { children, className } = props;
 
-  return <table className={`table ${styleName || ''}`}>{children}</table>;
+  return <table className={`table ${className || ''}`}>{children}</table>;
 };
 
 export default Table;

--- a/client/src/pages/LibrarySearchPage/LibrarySearchPage.js
+++ b/client/src/pages/LibrarySearchPage/LibrarySearchPage.js
@@ -21,7 +21,7 @@ class LibrarySearchPage extends Component {
 
               <div className="library-search__search-container">
                 <Form
-                  styleName="mr-2"
+                  className="mr-2"
                   action={searchLibrary}
                   options={options}
                   {...this.props}

--- a/client/src/pages/UserSearchPage/UserSearchPage.js
+++ b/client/src/pages/UserSearchPage/UserSearchPage.js
@@ -55,7 +55,7 @@ class UserSearchPage extends Component {
 
               <div className="user-search__search-container">
                 <Form
-                  styleName="mr-2"
+                  className="mr-2"
                   action={usersSearch}
                   options={options}
                   {...this.props}


### PR DESCRIPTION
## Description

Renames styleName props in React components to className.

This should unify the behavior for passing className props to presentational React components vs DOM elements