### PR TITLE
Directly import Sass index.scss

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,13 +4,12 @@
   "private": true,
   "proxy": "http://localhost:5000/",
   "scripts": {
-    "start": "concurrently \"react-scripts start\" \"npm run watch:sass\"",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
     "styleguide": "styleguidist server",
-    "styleguide:build": "styleguidist build",
-    "watch:sass": "node-sass-chokidar ./src/sass/index.scss -o ./src --watch"
+    "styleguide:build": "styleguidist build"
   },
   "dependencies": {
     "axios": "^0.18.0",

--- a/client/src/components/Root/Root.js
+++ b/client/src/components/Root/Root.js
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 import { createStore, applyMiddleware, compose } from 'redux';
 import reduxThunk from 'redux-thunk';
 import reducers from '../../reducers';
-import '../../index.css';
+import '../../sass/index.scss';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 

--- a/client/src/layouts/HomeLayout/_HomeLayout.scss
+++ b/client/src/layouts/HomeLayout/_HomeLayout.scss
@@ -6,7 +6,7 @@
 
   &__background {
     background: url(
-      images/cassette_tapes.jpg
+      ../images/cassette_tapes.jpg
     ) no-repeat center fixed;
     background-size: cover;
   }


### PR DESCRIPTION
## Issue

This issue resolves #275 

## Description

Removes the need for running the sass:watch script by directly importing the `index.scss` entrypoint rather than importing a generated `index.css`
