### PR TITLE
Add a "Getting Started" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,24 @@ Use [the Waffle board](https://waffle.io/codefordenver/Comrad) for this repo to 
 Here is what you need to know:
 
 This project uses [GitHub flow](https://guides.github.com/introduction/flow/) where updates are made on feature branches. Pull requests are submitted on those branches and reviewed before being merged.
+
+## Getting Started
+
+Clone and install dependencies in both the root directory and in `client/`:
+
+```shell
+$ git clone https://github.com/codefordenver/Comrad.git
+# ...
+$ cd Comrad/
+$ npm ci
+# ...
+$ cd client/
+$ npm ci
+# ...
+```
+
+_Note the use of the npm `ci` command instead of `install`: this installs the exact package versions specified in `package-lock.json` rather than the fuzzy-matched versions in `package.json`, thus giving you a more exact replica of the dependencies and avoiding [much confusion](https://stackoverflow.com/questions/45022048/why-does-npm-install-rewrite-package-lock-json)._
+
+Use `npm run` to see a list of available commands.
+
+To configure your environment variables (e.g. for database connection) ask a maintainer for the details.


### PR DESCRIPTION
## Guidelines

DEVELOPMENT branch on the LEFT <br>
YOUR branch on the RIGHT

## Issue

This issue resolves [N/A]

## Description

Include basic installation / config instructions in the README, including a caveat re: using `npm ci` instead of `npm install` to install a more exact dependency tree, useful for first-time setup.