### PR TITLE
Fix for issue where newly created tracks didn't have artist & album data

### DIFF
--- a/client/src/pages/TrackAddPage/TrackAddPage.js
+++ b/client/src/pages/TrackAddPage/TrackAddPage.js
@@ -22,7 +22,7 @@ class TrackAddPage extends Component {
   addTrackCallback = trackData => {
     const { albumActions, alertActions, history } = this.props;
     albumActions.clear();
-    history.push(`/library/album/${trackData.album}`);
+    history.push(`/library/album/${trackData.album._id}`);
     alertActions.show(
       'success',
       'Success',

--- a/server/v1/controllers/tracks/create.js
+++ b/server/v1/controllers/tracks/create.js
@@ -4,6 +4,7 @@ const { validateTrackData } = require('./utils');
 function create(req, res) {
   validateTrackData(req.body)
     .then(() => db.Track.create(req.body))
+    .then(dbTrack => db.Track.populate(dbTrack, ['album', 'artists']))
     .then(dbTrack => res.json(dbTrack))
     .catch(err => {
       console.log(err);


### PR DESCRIPTION
## Guidelines

DEVELOPMENT branch on the LEFT <br>
YOUR branch on the RIGHT

## Issue

This issue resolves #534 

## Description

- Fixes a problem where the API endpoint to add a track wasn't returning full album & artist data, which caused display issues on the Add Track page.
