### PR TITLE
Fix memory leak in Dropdown component

### DIFF
--- a/client/src/components/Dropdown/Dropdown.js
+++ b/client/src/components/Dropdown/Dropdown.js
@@ -93,6 +93,11 @@ class Dropdown extends Component {
     }
   }
 
+  componentWillUnmount() {
+    const { removeClickListener } = this;
+    removeClickListener();
+  }
+
   handleOnClick = e => {
     const { node } = this;
     const { target } = e;


### PR DESCRIPTION
## Guidelines

DEVELOPMENT branch on the LEFT <br>
YOUR branch on the RIGHT

## Issue

This issue resolves #563 

## Description

Fixes a memory leak in the `Dropdown` component. A state update could fire after the component unmounted because the document event listener wasn't being removed when the component unmounted. This fixes that.
