### PR TITLE
Add configuration setting for whether we are in a compliance reportin…

### DIFF
--- a/client/src/api/config/getInComplianceReportingPeriodSetting.js
+++ b/client/src/api/config/getInComplianceReportingPeriodSetting.js
@@ -1,0 +1,6 @@
+import axios from 'axios';
+import { ROOT_CONFIG_URL } from '../root';
+
+export function getInComplianceReportingPeriodSetting(modelName) {
+  return axios.get(`${ROOT_CONFIG_URL}/inComplianceReportingPeriod`);
+}

--- a/client/src/api/config/index.js
+++ b/client/src/api/config/index.js
@@ -1,5 +1,7 @@
 import { customFieldsForModel } from './customFieldsForModel';
+import { getInComplianceReportingPeriodSetting } from './getInComplianceReportingPeriodSetting';
 
 export const configAPI = {
   customFieldsForModel,
+  getInComplianceReportingPeriodSetting,
 };

--- a/client/src/pages/ShowBuilderPage/ShowBuilderPage.js
+++ b/client/src/pages/ShowBuilderPage/ShowBuilderPage.js
@@ -24,6 +24,7 @@ import ShowModalController from '../../components/Shows/ShowModalController';
 
 import {
   alertActions,
+  configActions,
   libraryActions,
   playlistActions,
   trafficActions,
@@ -51,11 +52,15 @@ class ShowBuilderPage extends Component {
     const {
       location,
       searchShow,
+      configActions,
       libraryActions,
       playlistActions,
       trafficActions,
     } = this.props;
     const { startTime, endTime } = queryString.parse(location.search);
+
+    //get the settings for whether we are in a compliance reporting period
+    configActions.getInComplianceReportingPeriodSetting();
 
     //clear any existing library search
     libraryActions.clear();
@@ -537,6 +542,7 @@ function mapStateToProps({ library, show, playlist, traffic }) {
 function mapDispatchToProps(dispatch) {
   return {
     alertActions: bindActionCreators({ ...alertActions }, dispatch),
+    configActions: bindActionCreators({ ...configActions }, dispatch),
     clearShows: bindActionCreators(clearShows, dispatch),
     createInstanceShow: bindActionCreators(createInstanceShow, dispatch),
     libraryActions: bindActionCreators({ ...libraryActions }, dispatch),

--- a/client/src/redux/config/actions/getInComplianceReportingPeriodSetting.js
+++ b/client/src/redux/config/actions/getInComplianceReportingPeriodSetting.js
@@ -1,0 +1,15 @@
+import { configTypes } from '../configTypes';
+import { configAPI } from '../../../api';
+
+export const getInComplianceReportingPeriodSetting = () => async dispatch => {
+  try {
+    const { data } = await configAPI.getInComplianceReportingPeriodSetting();
+
+    dispatch({
+      type: configTypes.IN_COMPLIANCE_REPORTING_PERIOD,
+      payload: data,
+    });
+  } catch (err) {
+    console.log(err);
+  }
+};

--- a/client/src/redux/config/actions/index.js
+++ b/client/src/redux/config/actions/index.js
@@ -1,5 +1,7 @@
 import { customFieldsForModel } from './customFieldsForModel';
+import { getInComplianceReportingPeriodSetting } from './getInComplianceReportingPeriodSetting';
 
 export const configActions = {
   customFieldsForModel,
+  getInComplianceReportingPeriodSetting,
 };

--- a/client/src/redux/config/configReducers.js
+++ b/client/src/redux/config/configReducers.js
@@ -2,6 +2,7 @@ import { configTypes } from './configTypes';
 
 const initialState = {
   customFields: {},
+  inComplianceReportingPeriod: null,
 };
 
 export const configReducer = (state = initialState, { type, payload }) => {
@@ -13,6 +14,12 @@ export const configReducer = (state = initialState, { type, payload }) => {
           ...state.customFields,
           ...payload,
         },
+      };
+
+    case configTypes.IN_COMPLIANCE_REPORTING_PERIOD:
+      return {
+        ...state,
+        inComplianceReportingPeriod: payload,
       };
 
     default:

--- a/client/src/redux/config/configTypes.js
+++ b/client/src/redux/config/configTypes.js
@@ -1,3 +1,4 @@
 export const configTypes = {
   CUSTOM_FIELDS_FOR_MODEL: 'configCustomFieldsForModel',
+  IN_COMPLIANCE_REPORTING_PERIOD: 'inComplianceReportingPeriod',
 };

--- a/server/v1/config/base.js
+++ b/server/v1/config/base.js
@@ -1,4 +1,5 @@
 module.exports = {
+  inComplianceReportingPeriod: true, // when true, users will be prompted to enter a label for any track that does not have one when adding a track to their Show Builder playlist
   modelCustomFields: {
     //TODO: move this to a place where it could be edited by whatever station is running comrad
     //schema for custom fields:

--- a/server/v1/controllers/config/getInComplianceReportingPeriodSetting.js
+++ b/server/v1/controllers/config/getInComplianceReportingPeriodSetting.js
@@ -1,0 +1,7 @@
+const keys = require('../../config/keys');
+
+function getInComplianceReportingPeriodSetting(req, res) {
+  res.status(200).json(keys.inComplianceReportingPeriod);
+}
+
+module.exports = getInComplianceReportingPeriodSetting;

--- a/server/v1/controllers/config/index.js
+++ b/server/v1/controllers/config/index.js
@@ -1,5 +1,7 @@
 const customFieldsForModel = require('./customFieldsForModel');
+const getInComplianceReportingPeriodSetting = require('./getInComplianceReportingPeriodSetting');
 
 module.exports = {
   customFieldsForModel,
+  getInComplianceReportingPeriodSetting,
 };

--- a/server/v1/routes/config.js
+++ b/server/v1/routes/config.js
@@ -2,5 +2,8 @@ const router = require('express').Router();
 const { configController } = require('../controllers');
 
 router.route('/fields/:modelName').get(configController.customFieldsForModel);
+router
+  .route('/inComplianceReportingPeriod')
+  .get(configController.getInComplianceReportingPeriodSetting);
 
 module.exports = router;


### PR DESCRIPTION
…g period

Depends on #584 

## Guidelines

DEVELOPMENT branch on the LEFT <br>
YOUR branch on the RIGHT

## Issue

This issue resolves #341  
This issue resolves #353 

## Description

- Adds a global setting for whether we are in a reporting period
- When we are in the reporting period, prompts users to enter a label for any tracks that are missing it
