### PR TITLE
end_time_utc was being re-calculated twice.

### DIFF
--- a/server/v1/controllers/shows/utils/utils.js
+++ b/server/v1/controllers/shows/utils/utils.js
@@ -242,8 +242,6 @@ function returnSeriesShowsArrayWithNewDates(dateArray, show) {
 
     end_time_utc = combineDayAndTime(date, end_time_utc, 'STRING', 'END');
 
-    end_time_utc = combineDayAndTime(date, end_time_utc, 'STRING', 'END');
-
     const series_event_id = newShow._id;
     newShow = { ...newShow, master_event_id: { _id: series_event_id } };
     newShow.master_time_id = master_time_id(series_event_id, start_time_utc);


### PR DESCRIPTION
## Guidelines

DEVELOPMENT branch on the LEFT <br>
YOUR branch on the RIGHT

## Description

There was a duplicated line, looks like it probably occurred during some merge conflict resolution.