### PR TITLE
461 calendar overflow issue

### DIFF
--- a/client/src/pages/CalendarHomePage/_CalendarHomePage.scss
+++ b/client/src/pages/CalendarHomePage/_CalendarHomePage.scss
@@ -10,6 +10,9 @@
     .DayPicker__horizontal,.CalendarMonth, .CalendarMonthGrid {
       background: none;
     }
+    .DayPicker_transitionContainer {
+      width: 200px !important;
+    }
     .DayPicker_weekHeaders__horizontal {
       margin-left: 0px;
     }


### PR DESCRIPTION
## Guidelines

DEVELOPMENT branch on the LEFT <br>
YOUR branch on the RIGHT

## Issue

This issue resolves #461 

## Description

Fixed issue by adding new style override for the Daypicker container in the CalendarHomePage.scss file. Adjusted width of container to prevent overflow.
