### PR TITLE
getting_started.md: Add note on specifying dotenv file if it's not

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -37,4 +37,10 @@ If, on using `npm run [command]`, you receive an error like the following:
 [1] However, a different version of babel-loader was detected higher up in the tree:
 ```
 
-Then, open/create the `.env` file in the client folder and add the line `SKIP_PREFLIGHT_CHECK=true`
+Then, open/create the `.env` file in the client folder and add the line `SKIP_PREFLIGHT_CHECK=true`.
+
+If you have to create a `.env` file in your client folder, you may also need to specify its location in the `server/index.js` file to avoid a Mongoose error. Edit line 1 as so:
+
+```
+require('dotenv').config({ path: 'client/.env' });
+```


### PR DESCRIPTION
## Description

Minor tweak to `getting_started.md` to account for error I encountered on clean install.