### PR TITLE
Transfer spaces after linebreaks correctly in Showbuilder scratch pad

### DIFF
--- a/client/src/utils/formatters.js
+++ b/client/src/utils/formatters.js
@@ -33,8 +33,7 @@ export const formatTotalSecondsAsMMSS = totalSeconds => {
  * @returns {String} a string with removed tags
  */
 export const stripHtml = html => {
-  html = html.replace('<br />', '\n');
-  html = html.replace('<br>', '\n');
+  html = html.replaceAll('</p>', '\n').trim('');
   var tmp = document.createElement('DIV');
   tmp.innerHTML = html;
   return tmp.textContent || tmp.innerText || '';


### PR DESCRIPTION
## Guidelines

DEVELOPMENT branch on the LEFT <br>
YOUR branch on the RIGHT

## Issue

This issue resolves #680 

## Description

Changed the regex in the stripHtml function to replace all instances of a closing p tag with a single line break, trim whitespace.
