### PR TITLE
Add copy icon to allow text copying from expanded sections in Show Builder Item

### DIFF
--- a/client/src/components/ShowBuilderItemList/ShowBuilderItem.js
+++ b/client/src/components/ShowBuilderItemList/ShowBuilderItem.js
@@ -176,6 +176,7 @@ const ShowBuilderItem = props => {
           {children}
           {children[0].props && (
             <i
+              title="Copy text to clipboard"
               class="fas fa-copy"
               onClick={() => {
                 const copiedText = stripHtml(

--- a/client/src/components/ShowBuilderItemList/ShowBuilderItem.js
+++ b/client/src/components/ShowBuilderItemList/ShowBuilderItem.js
@@ -171,12 +171,20 @@ const ShowBuilderItem = props => {
             'show-builder-item__details',
             expanded ? 'show-builder-item__details--expanded' : '',
           )}
-          onDragStart={e => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
         >
           {children}
+          {children[0].props && (
+            <i
+              class="fas fa-copy"
+              onClick={() => {
+                navigator.clipboard.writeText(
+                  JSON.stringify(
+                    children[0].props.dangerouslySetInnerHTML.__html,
+                  ),
+                );
+              }}
+            ></i>
+          )}
         </div>
       )}
     </div>

--- a/client/src/components/ShowBuilderItemList/ShowBuilderItem.js
+++ b/client/src/components/ShowBuilderItemList/ShowBuilderItem.js
@@ -6,6 +6,7 @@ import { playlistActions } from '../../redux';
 import classnames from 'classnames';
 
 import Button from '../Button';
+import { stripHtml } from '../../utils/formatters';
 
 const SHOW_BUILDER_ITEM_TYPE = 'show_builder_item';
 
@@ -177,11 +178,12 @@ const ShowBuilderItem = props => {
             <i
               class="fas fa-copy"
               onClick={() => {
-                navigator.clipboard.writeText(
+                const copiedText = stripHtml(
                   JSON.stringify(
                     children[0].props.dangerouslySetInnerHTML.__html,
                   ),
-                );
+                ).replaceAll('\\"', '');
+                navigator.clipboard.writeText(copiedText);
               }}
             ></i>
           )}

--- a/client/src/components/ShowBuilderItemList/ShowBuilderItem.js
+++ b/client/src/components/ShowBuilderItemList/ShowBuilderItem.js
@@ -166,10 +166,15 @@ const ShowBuilderItem = props => {
       </div>
       {children && (
         <div
+          draggable
           className={classnames(
             'show-builder-item__details',
             expanded ? 'show-builder-item__details--expanded' : '',
           )}
+          onDragStart={e => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
         >
           {children}
         </div>
@@ -188,7 +193,4 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ShowBuilderItem);
+export default connect(mapStateToProps, mapDispatchToProps)(ShowBuilderItem);

--- a/client/src/components/ShowBuilderItemList/_ShowBuilderItemList.scss
+++ b/client/src/components/ShowBuilderItemList/_ShowBuilderItemList.scss
@@ -91,9 +91,18 @@
       padding: 0.2em 0.5em;
       margin-top: 0.3em;
       display: none;
+      position: relative;
       
       &--expanded {
         display: block;
+      }
+
+      .fa-copy {
+        position: absolute;
+        right: 0;
+        top: 0;
+        margin-top: 5px;
+        margin-right: 5px;
       }
       
       b {

--- a/client/src/components/ShowBuilderItemList/_ShowBuilderItemList.scss
+++ b/client/src/components/ShowBuilderItemList/_ShowBuilderItemList.scss
@@ -102,6 +102,7 @@
         right: 0;
         top: 0;
         padding: 5px;
+        cursor: pointer;
       }
       
       b {

--- a/client/src/components/ShowBuilderItemList/_ShowBuilderItemList.scss
+++ b/client/src/components/ShowBuilderItemList/_ShowBuilderItemList.scss
@@ -101,8 +101,7 @@
         position: absolute;
         right: 0;
         top: 0;
-        margin-top: 5px;
-        margin-right: 5px;
+        padding: 5px;
       }
       
       b {


### PR DESCRIPTION
## Guidelines

DEVELOPMENT branch on the LEFT <br>
YOUR branch on the RIGHT

## Issue

This issue resolves #655 

## Description

Original request to allow highlighting text in drop down menu had no straightforward method of implementation due to limitations with the library used that enables item dragging. Opted instead to add a "Copy" icon to the section that will copy the text to the clipboard when clicked.
