### PR TITLE
Assign default false value to custom.record_audio for new shows

### DIFF
--- a/client/src/redux/show/showActions.js
+++ b/client/src/redux/show/showActions.js
@@ -40,6 +40,14 @@ export const postShow = (input, callback) => async dispatch => {
       show.repeat_rule.repeat_end_date = repeatEndDate.toDate();
     }
 
+    if (show.show_details.custom == null) {
+      show.show_details.custom = {};
+    }
+
+    if (show.show_details.custom.record_audio == null) {
+      show.show_details.custom.record_audio = false;
+    }
+
     const response = await axios.post(`${ROOT_SHOWS_URL}/`, show);
 
     dispatch({ type: SHOW_UPDATE, payload: response.data });


### PR DESCRIPTION
## Guidelines

DEVELOPMENT branch on the LEFT <br>
YOUR branch on the RIGHT

## Issue

This issue resolves #877 

## Description

Added conditional to set `custom.record_audio` attribute to `false` when not specified otherwise.